### PR TITLE
Version 2.9.0post0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,8 @@ test:
   requires:
     - pip
     - importlib_metadata
+  commands:
+    - pip check
 
 about:
   home: https://dateutil.readthedocs.io/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,33 +1,22 @@
-# NOT FOR DEFAULTS.
 package:
   name: python-dateutil
-  # The Python packaging ecosystem and conda support what's called a local version identifier (https://peps.python.org/pep-0440/#local-version-identifiers). 
-  # So instead of 2.8.3a1 use 2.8.3+snowflake<n>
-  version: 2.8.3+snowflake1
+  version: 2.9.0post0
 
 source:
   url: https://pypi.io/packages/source/p/python-dateutil/python-dateutil-2.8.2.tar.gz
   sha256: 0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86
-  patches:
-    - new_tzfile.patch
-    - fix_version.patch
 
 build:
-  # Bump the build number to ensure that 2.8.3+snowflake1 is greater than 2.8.3a1
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
-  build:
-    - m2-patch  # [win]
-    - patch     # [not win]
   host:
     - python
     - pip
     - wheel
     - setuptools
-    # Disable setuptools_scm because we patch the package version vy 'fix_version.patch'
-    #- setuptools_scm
+    - setuptools_scm
   run:
     - python
     - six >=1.5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,21 +1,34 @@
 package:
   name: python-dateutil
+  # The Python packaging ecosystem and conda support what's called a local version identifier (https://peps.python.org/pep-0440/#local-version-identifiers).
+  # So instead of 2.8.3a1 use 2.8.3+snowflake<n>
+  # version: 2.8.3+snowflake1
   version: 2.9.0post0
 
 source:
   url: https://pypi.io/packages/source/p/python-dateutil/python-dateutil-2.8.2.tar.gz
   sha256: 0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86
+  # For snowflake version
+  # patches:
+  #   - new_tzfile.patch
+  #   - fix_version.patch
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
+  # For snowflake version
+  # build:
+  #   - m2-patch  # [win]
+  #   - patch     # [not win]
   host:
     - python
     - pip
     - wheel
     - setuptools
+    # Disable setuptools_scm because we patch the package version vy 'fix_version.patch'
+    # Enable for defaults version
     - setuptools_scm
   run:
     - python

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -8,8 +8,6 @@ from dateutil import zoneinfo, utils
 from importlib_metadata import version
 
 
-# Test pip check
-subprocess.run(["pip", "check"])
 
 # Enable for snowflake version
 # assert version("python-dateutil") == "2.8.3+snowflake1"

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -11,7 +11,8 @@ from importlib_metadata import version
 # Test pip check
 subprocess.run(["pip", "check"])
 
-assert version("python-dateutil") == "2.8.3+snowflake1"
+# Not needed for the defaults version
+# assert version("python-dateutil") == "2.8.3+snowflake1"
 
 now = parse("Sat Oct 11 17:13:46 UTC 2003")
 today = now.date()

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -11,7 +11,7 @@ from importlib_metadata import version
 # Test pip check
 subprocess.run(["pip", "check"])
 
-# Not needed for the defaults version
+# Enable for snowflake version
 # assert version("python-dateutil") == "2.8.3+snowflake1"
 
 now = parse("Sat Oct 11 17:13:46 UTC 2003")


### PR DESCRIPTION
python-dateutil 2.9.0post0

**Destination channel:** defaults

### Links

- [PKG-4506](https://anaconda.atlassian.net/browse/PKG-4506)
- [Upstream repository](https://github.com/dateutil/dateutil/tree/2.9.0.post0)
- [Upstream changelog/diff](https://github.com/dateutil/dateutil/releases)

### Explanation of changes:
- Update version
- Modify `meta.yaml` and `runtest.py` to make it easier to switch between snowflake and defaults versions
- Linter fixes


[PKG-4506]: https://anaconda.atlassian.net/browse/PKG-4506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ