### PR TITLE
PKG-4848 v2.9.0post0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,19 @@
 {% set name = "python-dateutil" %}
-{% set version = "2.9.0.post0" %}
+# two versions here is a temporary fix to make sure this package takes precedence over the current
+# incorrect package 2.9.0post0
+{% set version = "2.9.0post0" %}
+{% set url_version = "2.9.0.post0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ url_version }}.tar.gz
   sha256: 37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3
 
 build:
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:


### PR DESCRIPTION
**Destination channel:** Defaults

### Links

- [PKG-4848](https://anaconda.atlassian.net/browse/PKG-4848) 

### Explanation of changes:

- v2.9.0.post0, released in [this](https://github.com/AnacondaRecipes/python-dateutil-feedstock/pull/6) PR, doesn't take precedence over v2.9.0post0, which was a version that incorrectly packaged v2.8.2. This is a second PR that returns the version string to v2.9.0post0 and bumps the build number again.


[PKG-4848]: https://anaconda.atlassian.net/browse/PKG-4848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ